### PR TITLE
[BUGF] [test_simple_vision_encoder.py ] [VisionEncoder]

### DIFF
--- a/tests/structs/test_simple_vision_encoder.py
+++ b/tests/structs/test_simple_vision_encoder.py
@@ -1,9 +1,9 @@
 import torch
-from zeta.structs.simple_vision_encoder import SimpleVisionEncoder
+from zeta.structs.simple_vision_encoder import VisionEncoder
 
 
 def test_simple_vision_encoder_init():
-    sve = SimpleVisionEncoder()
+    sve = VisionEncoder()
     assert sve.size == (384, 384)
     assert sve.model_name == "vikhyatk/moondream0"
     assert sve.return_shape is False
@@ -13,15 +13,15 @@ def test_simple_vision_encoder_init():
 
 
 def test_simple_vision_encoder_init_custom_size():
-    sve = SimpleVisionEncoder(size=(512, 512))
+    sve = VisionEncoder(size=(512, 512))
     assert sve.size == (512, 512)
 
 
 def test_simple_vision_encoder_init_custom_model_name():
-    sve = SimpleVisionEncoder(model_name="custom/model")
+    sve = VisionEncoder(model_name="custom/model")
     assert sve.model_name == "custom/model"
 
 
 def test_simple_vision_encoder_init_return_shape():
-    sve = SimpleVisionEncoder(return_shape=True)
+    sve = VisionEncoder(return_shape=True)
     assert sve.return_shape is True


### PR DESCRIPTION
```

modified:   tests/structs/test_simple_vision_encoder.py

________________________________________________________________________ ERROR collecting tests/structs/test_simple_vision_encoder.py _________________________________________________________________________
ImportError while importing test module '/home/v/vzeta/tests/structs/test_simple_vision_encoder.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/structs/test_simple_vision_encoder.py:2: in <module>
    from zeta.structs.simple_vision_encoder import SimpleVisionEncoder
E   ImportError: cannot import name 'SimpleVisionEncoder' from 'zeta.structs.simple_vision_encoder' (/home/v/.local/lib/python3.10/site-packages/zeta/structs/simple_vision_encoder.py)

```