### PR TITLE
[BUGF] [RESIDUALBLOCK] [TEST_SIMPLE_MAMABA.PY]

### DIFF
--- a/tests/nn/modules/test_simple_mamba.py
+++ b/tests/nn/modules/test_simple_mamba.py
@@ -4,9 +4,10 @@ from torch import nn
 from zeta.nn.modules.simple_mamba import (
     Mamba,
     MambaBlock,
-    ResidualBlock,
     RMSNorm,
 )
+
+from zeta.rl.vision_model_rl import ResidualBlock
 
 
 def test_mamba_class_init():


### PR DESCRIPTION
```
from zeta.rl.vision_model_rl import ResidualBlock

__________________ ERROR collecting tests/nn/modules/test_simple_mamba.py ___________________
ImportError while importing test module '/home/v/vzeta/tests/nn/modules/test_simple_mamba.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/nn/modules/test_simple_mamba.py:4: in <module>
    from zeta.nn.modules.simple_mamba import (
E   ImportError: cannot import name 'ResidualBlock' from 'zeta.nn.modules.simple_mamba' (/home/v/.local/lib/python3.10/site-packages/zeta/nn/modules/simple_mamba.py)
```