### PR TITLE
[BUGF] [Laser] [laser.py]

### DIFF
--- a/tests/nn/modules/test_laser.py
+++ b/tests/nn/modules/test_laser.py
@@ -1,29 +1,29 @@
 import torch
 import pytest
-from zeta.nn.modules.laser import LASER
+from zeta.nn.modules.laser import Laser
 
 
 def test_laser_init():
-    laser = LASER(0.5)
+    laser = Laser(0.5)
     assert laser.rank_fraction == 0.5
 
 
 def test_laser_forward_2d():
-    laser = LASER(0.5)
+    laser = Laser(0.5)
     W = torch.randn(10, 10)
     W_approx = laser(W)
     assert W_approx.shape == W.shape
 
 
 def test_laser_forward_3d():
-    laser = LASER(0.5)
+    laser = Laser(0.5)
     W = torch.randn(5, 10, 10)
     W_approx = laser(W)
     assert W_approx.shape == W.shape
 
 
 def test_laser_low_rank_approximation():
-    laser = LASER(0.5)
+    laser = Laser(0.5)
     W = torch.randn(10, 10)
     W_approx = laser.low_rank_approximation(W)
     assert W_approx.shape == W.shape
@@ -31,4 +31,4 @@ def test_laser_low_rank_approximation():
 
 def test_laser_rank_fraction_out_of_range():
     with pytest.raises(AssertionError):
-        LASER(1.5)
+        Laser(1.5)


### PR DESCRIPTION
```

_________________________________________________ ERROR collecting tests/nn/modules/test_laser.py _________________________________________________
ImportError while importing test module '/home/v/vzeta/tests/nn/modules/test_laser.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/nn/modules/test_laser.py:3: in <module>
    from zeta.nn.modules.laser import LASER
E   ImportError: cannot import name 'LASER' from 'zeta.nn.modules.laser' (/home/v/.local/lib/python3.10/site-packages/zeta/nn/modules/laser.py)
```