### PR TITLE
[BUGF] README.md [RELATIVE POSITION BIAS] 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ swiglu(x).shape
 - ```RelativePositionBias``` quantizes the distance between two positions into a certain number of buckets and then uses an embedding to get the relative position bias. This mechanism aids in the attention mechanism by providing biases based on relative positions between the query and key, rather than relying solely on their absolute positions.
 ```python
 import torch
+from torch import nn
 from zeta.nn import RelativePositionBias
 
 # Initialize the RelativePositionBias module
@@ -81,7 +82,7 @@ class MockAttention(nn.Module):
         return None  # Placeholder
 
 # Example 3: Modify default configurations
-custom_rel_pos_bias = RelativePositionBias(bidirectional=False, num_buckets=64, max_distance=256, n_heads=8)
+custom_rel_pos_bias = RelativePositionBias(bidirectional=False, num_buckets=64, max_distance=256, num_heads=8)
 
 ```
 


### PR DESCRIPTION
relative position bias 

- from torch import nn 
- RelativePositionBias(..., num_heads=8)

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
[<ipython-input-15-5b68987ab208>](https://localhost:8080/#) in <cell line: 23>()
     21 
     22 # Example 3: Modify default configurations
---> 23 custom_rel_pos_bias = RelativePositionBias(bidirectional=False, num_buckets=64, max_distance=256, n_heads=8)
     24 
     25 

TypeError: RelativePositionBias.__init__() got an unexpected keyword argument 'n_heads'
```