### PR TITLE
Custom MLP forward pass example fix #118

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,4 +17,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v3
+        uses: actions/dependency-review-action@v4

--- a/docs/zeta/nn/modules/custom_mlp.md
+++ b/docs/zeta/nn/modules/custom_mlp.md
@@ -110,12 +110,21 @@ mlp = CustomMLP(layer_sizes=[20, 10, 5], activation='sigmoid', dropout=0.2)
 
 ```python
 import torch
+from zeta.nn import CustomMLP
 
-# Input data (batch of 5 samples with 10 features each)
-input_data = torch.randn(5, 10)
+# Define the layer sizes
+layer_sizes = [5, 10, 1]
 
-# Forward pass through the MLP
-output = mlp(input_data)
+# Create the MLP
+mlp = CustomMLP(layer_sizes, activation="relu", dropout=0.5)
+
+# Create a random tensor of shape (batch_size, input_size)
+x = torch.randn(32, 5)
+
+# Pass the tensor through the MLP
+output = mlp(x)
+
+print(output)
 ```
 
 ### Example 3: Customizing and Forward Pass


### PR DESCRIPTION
This is a docs example fix for #118

<!-- readthedocs-preview zeta start -->
----
📚 Documentation preview 📚: https://zeta--119.org.readthedocs.build/en/119/

<!-- readthedocs-preview zeta end -->