### PR TITLE
[FIX][CLEANUP] Module import, remove version testing in code

### DIFF
--- a/playground/models/stacked_mm_bitnet.py
+++ b/playground/models/stacked_mm_bitnet.py
@@ -14,7 +14,6 @@ from typing import Callable, List, Optional, Tuple
 import torch
 import torch.nn.functional as F
 from einops import pack, rearrange, reduce, repeat, unpack
-from packaging import version
 from torch import Tensor, einsum, nn
 from zeta.quant.bitlinear import BitLinear
 
@@ -153,13 +152,6 @@ class Attend(nn.Module):
         # flash attention
 
         self.flash = flash
-        assert not (
-            flash and version.parse(torch.__version__) < version.parse("2.0.0")
-        ), (
-            "in order to use flash attention, you must be using pytorch 2.0 or"
-            " above"
-        )
-
         self.sdp_kwargs = sdp_kwargs
 
     def flash_attn(self, q, k, v, mask=None, attn_bias=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ numexpr = "*"
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
+
 [tool.poetry.group.lint.dependencies]
 ruff = ">=0.0.249,<0.2.2"
 types-toml = "^0.10.8.1"
@@ -60,6 +61,7 @@ types-pytz = ">=2023.3,<2025.0"
 black = "^23.1.0"
 types-chardet = "^5.0.4.6"
 mypy-protobuf = "^3.0.0"
+pytest = "7.4.2"
 
 
 [tool.autopep8]

--- a/tests/nn/modules/test_mishactivation.py
+++ b/tests/nn/modules/test_mishactivation.py
@@ -3,16 +3,11 @@
 import torch
 from zeta.nn import MishActivation
 from torch import nn
-from packaging import version
 
 
 def test_MishActivation_init():
     mish_activation = MishActivation()
-
-    if version.parse(torch.__version__) < version.parse("1.9.0"):
-        assert mish_activation.act == mish_activation._mish_python
-    else:
-        assert mish_activation.act == nn.functional.mish
+    assert mish_activation.act == nn.functional.mish
 
 
 def test__mish_python():
@@ -27,9 +22,6 @@ def test_forward():
     mish_activation = MishActivation()
     input = torch.tensor([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
 
-    if version.parse(torch.__version__) < version.parse("1.9.0"):
-        expected_output = input * torch.tanh(nn.functional.softplus(input))
-    else:
-        expected_output = nn.functional.mish(input)
+    expected_output = nn.functional.mish(input)
 
     assert torch.equal(mish_activation.forward(input), expected_output)

--- a/zeta/nn/attention/attend.py
+++ b/zeta/nn/attention/attend.py
@@ -6,7 +6,6 @@ from typing import Optional
 import torch
 import torch.nn.functional as F
 from einops import rearrange, repeat
-from packaging import version
 from torch import Tensor, einsum, nn
 
 # constants
@@ -144,12 +143,6 @@ class Attend(nn.Module):
         # flash attention
 
         self.flash = flash
-        assert not (
-            flash and version.parse(torch.__version__) < version.parse("2.0.0")
-        ), (
-            "in order to use flash attention, you must be using pytorch 2.0 or"
-            " above"
-        )
 
         # determine efficient attention configs for cuda and cpu
 

--- a/zeta/nn/attention/flash_attention.py
+++ b/zeta/nn/attention/flash_attention.py
@@ -5,7 +5,7 @@ from functools import wraps
 import torch
 import torch.nn.functional as F
 from einops import rearrange
-from packaging import version
+
 from torch import Tensor, einsum, nn
 
 from zeta.nn.attention.base import BaseAttention
@@ -96,13 +96,6 @@ class FlashAttention(BaseAttention):
 
         self.causal = causal
         self.flash = flash
-        assert not (
-            flash and version.parse(torch.__version__) < version.parse("2.0.0")
-        ), (
-            "in order to use flash attention, you must be using pytorch 2.0 or"
-            " above"
-        )
-
         # determine efficient attention configs for cuda and cpu
 
         self.cpu_config = EfficientAttentionConfig(True, True, True)

--- a/zeta/nn/modules/_activations.py
+++ b/zeta/nn/modules/_activations.py
@@ -2,7 +2,6 @@ import math
 from collections import OrderedDict
 
 import torch
-from packaging import version
 from torch import Tensor, nn
 import logging
 
@@ -22,11 +21,6 @@ class PytorchGELUTanh(nn.Module):
 
     def __init__(self):
         super().__init__()
-        if version.parse(torch.__version__) < version.parse("1.12.0"):
-            raise ImportError(
-                f"You are using torch=={torch.__version__}, but torch>=1.12.0"
-                " is required to use PytorchGELUTanh. Please upgrade torch."
-            )
 
     def forward(self, input: Tensor) -> Tensor:
         return nn.functional.gelu(input, approximate="tanh")
@@ -162,10 +156,7 @@ class MishActivation(nn.Module):
 
     def __init__(self):
         super().__init__()
-        if version.parse(torch.__version__) < version.parse("1.9.0"):
-            self.act = self._mish_python
-        else:
-            self.act = nn.functional.mish
+        self.act = nn.functional.mish
 
     def _mish_python(self, input: Tensor) -> Tensor:
         return input * torch.tanh(nn.functional.softplus(input))

--- a/zeta/nn/modules/freeze_layers.py
+++ b/zeta/nn/modules/freeze_layers.py
@@ -1,5 +1,5 @@
-from torch import Module
 
+from torch.nn import Module
 
 def set_module_requires_grad(
     module: Module,

--- a/zeta/utils/__init__.py
+++ b/zeta/utils/__init__.py
@@ -36,6 +36,7 @@ from zeta.utils.main import (
     cast_if_src_dtype,
     get_sinusoid_encoding_table,
     interpolate_pos_encoding_2d,
+    seek_all_images,
 )
 
 from zeta.utils.enforce_types import enforce_types

--- a/zeta/utils/__init__.py
+++ b/zeta/utils/__init__.py
@@ -93,4 +93,5 @@ __all__ = [
     "append_nvcc_threads",
     "check_cuda",
     "VerboseExecution",
+    "seek_all_images"
 ]


### PR DESCRIPTION
Tests were failing with a bad import:
``` 
from torch import Module
```
in freeze layers.

There were also several instances of checking for and handling old version of pytorch, which I removed now that dependencies are handled by poetry.