### PR TITLE
Update multihead_attention.py

### DIFF
--- a/zeta/nn/attention/multihead_attention.py
+++ b/zeta/nn/attention/multihead_attention.py
@@ -19,7 +19,7 @@ class MultiheadAttention(BaseAttention):
         self,
         embed_dim: int = None,
         num_heads: int = None,
-        dropout: int = 0.0,
+        dropout: float = 0.0,
         self_attention: bool = False,
         subln: bool = False,
         layernorm_eps=1e-05,


### PR DESCRIPTION
just updated a minute error dropout was set to int instead of float.
it was defined as dropout : int = 0.0
changed to dropout : float = 0.0

<!-- Thank you for contributing to Zeta!

Replace this comment with:
  - Description: I just updated a minute error dropout was set to int instead of float.
  - Dependencies: no dependencies required for this change,
  - Tag maintainer: kye@apac.ai,
  - Twitter handle: This minor change isn't worth it