### PR TITLE
fix: package name collision

### DIFF
--- a/zeta/experimental/triton/activations/activations.py
+++ b/zeta/experimental/triton/activations/activations.py
@@ -2,7 +2,7 @@ import torch
 import triton
 
 from typing import Callable
-from activations.functions import Functions
+from zeta.experimental.triton.activations.functions import Functions
 
 BLOCK_SIZE = 1024
 


### PR DESCRIPTION
Current reference collides with another package name `activations` that is used in zeta